### PR TITLE
feat: #3524328 Add Re-generate button

### DIFF
--- a/src/Form/GeneratedContentForm.php
+++ b/src/Form/GeneratedContentForm.php
@@ -87,20 +87,33 @@ class GeneratedContentForm extends FormBase implements ContainerInjectionInterfa
       '#type' => 'tableselect',
       '#header' => $header,
       '#options' => $options,
-      '#empty' => $this->t('No generated content implementations found. Please refer to <code>generated_content.api.php</code>.'),
+      '#empty' => $this->t('No generated content implementations found. To get started, create a <code>generated_content/{entity_type}/{bundle}.inc</code> file in your module and implement a <code>hook_generated_content_create_{entity_type}_{bundle}()</code> callback. See <code>generated_content.api.php</code> for examples.'),
     ];
 
-    $form['generate'] = [
-      '#type' => 'submit',
-      '#name' => 'generate',
-      '#value' => $this->t('Generate'),
-    ];
+    if (!empty($options)) {
+      $form['actions_description'] = [
+        '#type' => 'markup',
+        '#markup' => '<p>' . $this->t('Select items to process or leave empty to process all items.') . '</p>',
+      ];
 
-    $form['delete'] = [
-      '#type' => 'submit',
-      '#name' => 'delete',
-      '#value' => $this->t('Delete'),
-    ];
+      $form['generate'] = [
+        '#type' => 'submit',
+        '#name' => 'generate',
+        '#value' => $this->t('▶ Generate'),
+      ];
+
+      $form['delete'] = [
+        '#type' => 'submit',
+        '#name' => 'delete',
+        '#value' => $this->t('✖ Delete'),
+      ];
+
+      $form['regenerate'] = [
+        '#type' => 'submit',
+        '#name' => 'regenerate',
+        '#value' => $this->t('⟳ Regenerate'),
+      ];
+    }
 
     return $form;
   }
@@ -133,6 +146,9 @@ class GeneratedContentForm extends FormBase implements ContainerInjectionInterfa
     }
     elseif ($button_name === 'delete') {
       $this->repository->removeBatch($info);
+    }
+    elseif ($button_name === 'regenerate') {
+      $this->repository->regenerateBatch($info);
     }
   }
 

--- a/src/GeneratedContentBatch.php
+++ b/src/GeneratedContentBatch.php
@@ -32,12 +32,29 @@ class GeneratedContentBatch {
       'finished' => '\Drupal\generated_content\GeneratedContentBatch::finished',
     ];
 
-    foreach ($info_items as $info_item) {
-      $batch['operations'][] = [
-        $op == 'create' ? '\Drupal\generated_content\GeneratedContentBatch::createSingle' : '\Drupal\generated_content\GeneratedContentBatch::removeSingle',
-        [$info_item, $total],
-      ];
+    if ($op === 'regenerate') {
+      foreach ($info_items as $info_item) {
+        $batch['operations'][] = [
+          '\Drupal\generated_content\GeneratedContentBatch::removeSingle',
+          [$info_item, $total],
+        ];
+      }
+      foreach ($info_items as $info_item) {
+        $batch['operations'][] = [
+          '\Drupal\generated_content\GeneratedContentBatch::createSingle',
+          [$info_item, $total],
+        ];
+      }
     }
+    else {
+      foreach ($info_items as $info_item) {
+        $batch['operations'][] = [
+          $op == 'create' ? '\Drupal\generated_content\GeneratedContentBatch::createSingle' : '\Drupal\generated_content\GeneratedContentBatch::removeSingle',
+          [$info_item, $total],
+        ];
+      }
+    }
+
     batch_set($batch);
   }
 

--- a/src/GeneratedContentRepository.php
+++ b/src/GeneratedContentRepository.php
@@ -318,6 +318,17 @@ class GeneratedContentRepository implements ContainerInjectionInterface {
   }
 
   /**
+   * Process regeneration of specified entities in a batch.
+   *
+   * @param array<mixed>|null $info
+   *   Info.
+   */
+  public function regenerateBatch(?array $info = NULL): void {
+    $info = $info ?: $this->getInfo();
+    GeneratedContentBatch::set('regenerate', $info, 1);
+  }
+
+  /**
    * Cleanup content.
    *
    * @param array<mixed> $info

--- a/tests/src/Functional/GeneratedContentGenerationFunctionalTest.php
+++ b/tests/src/Functional/GeneratedContentGenerationFunctionalTest.php
@@ -52,7 +52,7 @@ class GeneratedContentGenerationFunctionalTest extends GeneratedContentFunctiona
       'table[node__page]' => TRUE,
       'table[node__article]' => TRUE,
     ];
-    $this->submitForm($edit, 'Generate');
+    $this->submitForm($edit, '▶ Generate');
     $this->assertInfoTableItems(0, 70, 10, 10, 10, 3, 10);
 
     $this->assertSession()->pageTextContains('Created an account generated_content_editor_1@example.com');
@@ -157,7 +157,7 @@ class GeneratedContentGenerationFunctionalTest extends GeneratedContentFunctiona
       'table[node__page]' => TRUE,
       'table[node__article]' => TRUE,
     ];
-    $this->submitForm($edit, 'Delete');
+    $this->submitForm($edit, '✖ Delete');
     $this->assertInfoTableItems(0, 0, 0, 0, 0, 0, 0);
 
     $this->assertSession()->pageTextContains('Removed all generated content entities "user" in bundle "user"');
@@ -168,6 +168,77 @@ class GeneratedContentGenerationFunctionalTest extends GeneratedContentFunctiona
     $this->assertSession()->pageTextContains('Removed all generated content entities "node" in bundle "page"');
     $this->assertSession()->pageTextContains('Removed all generated content entities "node" in bundle "article"');
     $this->assertSession()->pageTextContains('7 items processed.');
+  }
+
+  /**
+   * Test regeneration of content.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   */
+  public function testRegenerate(): void {
+    $admin = $this->createUser([], NULL, TRUE);
+    if (!$admin instanceof AccountInterface) {
+      throw new \RuntimeException('Admin user creation failed.');
+    }
+
+    $this->drupalLogin($admin);
+
+    $this->drupalGet('/admin/config/development/generated-content');
+
+    $edit = [
+      'table[taxonomy_term__tags]' => TRUE,
+      'table[node__page]' => TRUE,
+    ];
+    $this->submitForm($edit, '▶ Generate');
+    $this->assertInfoTableItems(0, 0, 0, 0, 10, 3, 0);
+
+    // Regenerate the same items.
+    $edit = [
+      'table[taxonomy_term__tags]' => TRUE,
+      'table[node__page]' => TRUE,
+    ];
+    $this->submitForm($edit, '⟳ Regenerate');
+    $this->assertInfoTableItems(0, 0, 0, 0, 10, 3, 0);
+
+    $this->assertSession()->pageTextContains('Removed all generated content entities "taxonomy_term" in bundle "tags"');
+    $this->assertSession()->pageTextContains('Removed all generated content entities "node" in bundle "page"');
+    $this->assertSession()->pageTextContains('Created generated content entities "taxonomy_term" with bundle "tags"');
+    $this->assertSession()->pageTextContains('Created generated content entities "node" with bundle "page"');
+  }
+
+  /**
+   * Test that buttons process all items when nothing is selected.
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   * @throws \Behat\Mink\Exception\ResponseTextException
+   */
+  public function testNoSelectionProcessesAll(): void {
+    $admin = $this->createUser([], NULL, TRUE);
+    if (!$admin instanceof AccountInterface) {
+      throw new \RuntimeException('Admin user creation failed.');
+    }
+
+    $this->drupalLogin($admin);
+
+    $this->drupalGet('/admin/config/development/generated-content');
+    $this->assertInfoTableItems(0, 0, 0, 0, 0, 0, 0);
+
+    // Generate with no selection should process all items.
+    $this->submitForm([], '▶ Generate');
+    $this->assertInfoTableItems(0, 70, 10, 10, 10, 3, 10);
+
+    // Delete with no selection should process all items.
+    $this->submitForm([], '✖ Delete');
+    $this->assertInfoTableItems(0, 0, 0, 0, 0, 0, 0);
+
+    // Regenerate with no selection should process all items.
+    // First generate content to have something to regenerate.
+    $this->submitForm([], '▶ Generate');
+    $this->assertInfoTableItems(0, 70, 10, 10, 10, 3, 10);
+
+    $this->submitForm([], '⟳ Regenerate');
+    $this->assertInfoTableItems(0, 70, 10, 10, 10, 3, 10);
   }
 
 }


### PR DESCRIPTION
By: alex.skrypnyk



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Adds a "Re-generate" button to the generated content form alongside the existing Generate and Delete actions, enabling users to regenerate previously created content in a single batch operation.

## Changes

### Form UI Updates (`src/Form/GeneratedContentForm.php`)
- Added new "⟳ Regenerate" action button to the form.
- Wrapped action buttons to show only when options exist and added an actions description explaining selection behavior.
- Updated button labels for consistency:
  - "Generate" → "▶ Generate"
  - "Delete" → "✖ Delete"
- Expanded form submission handler to process the regenerate action by calling repository->regenerateBatch($info).

### Batch Operation Logic (`src/GeneratedContentBatch.php`)
- Introduced dedicated handling for `op === 'regenerate'` operations.
- Implements two-pass batch processing:
  1. First pass: enqueue `removeSingle` for all items.
  2. Second pass: enqueue `createSingle` for all items.
- Preserves existing per-item single-pass logic for other operations.

### Repository API (`src/GeneratedContentRepository.php`)
- Added `public function regenerateBatch(?array $info = NULL): void`.
- Mirrors `removeBatch` pattern and calls `GeneratedContentBatch::set` with type 'regenerate' and batch size of 1.

### Tests (`tests/src/Functional/GeneratedContentGenerationFunctionalTest.php`)
- Updated `testGenerateDelete()` to use new button labels.
- Added `testRegenerate()` to validate regeneration performs removal then creation for affected entities.
- Added `testNoSelectionProcessesAll()` to verify that when no items are selected, Generate/Delete/Regenerate act on all items.

## Impact
Medium review effort. Introduces a new observable batch operation (regenerate) and UI affordance without changing existing public method signatures (aside from adding regenerateBatch).

Possibly related to #3524328.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->