### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,19 +4,21 @@
     "rangeStrategy": "bump",
     "dependencyDashboard": true,
     "pinDigests": true,
-    "major": {
-        "enabled": false
-    },
-    "groupName": "all dependencies",
-    "groupSlug": "all",
     "branchPrefix": "deps/",
-    "composer": {
-        "managerFilePatterns": ["/composer\\.dev\\.json$/"]
-    },
     "packageRules": [
         {
+            "matchDepNames": ["php"],
             "matchManagers": ["composer"],
-            "matchFileNames": ["composer.json"],
+            "enabled": false
+        },
+        {
+            "matchDepNames": ["node", "yarn"],
+            "matchManagers": ["npm"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["npm", "composer"],
+            "matchUpdateTypes": ["major"],
             "enabled": false
         },
         {


### PR DESCRIPTION
Updated renovate config via 🤠 RepoRanger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the Renovate configuration to provide more granular control over dependency updates. The changes reorganize package rules to better manage which dependencies and update types are automatically processed.

## Changes Made

**renovate.json:**
- Removed top-level Renovate config blocks: `major`, `groupName`, `groupSlug`, and `composer` managerFilePatterns
- Restructured package rules to provide per-rule specificity:
  - Added rule to disable updates for `php` in Composer
  - Added rule to disable updates for `node` and `yarn` in npm
  - Added rule to disable major version updates across npm and Composer
  - Preserved catch-all rule for grouping all dependencies

**Lines changed:** +11/-9

**Effort:** Medium - Configuration update with reorganized rules

## Possibly Related

This PR builds on the initial Renovate setup work established in previous efforts (see commit history with "Configure Renovate" reference), providing ongoing refinement to the dependency update automation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->