### PR TITLE
Updated scaffold to 4.15.2.

### DIFF
--- a/composer.dev.json
+++ b/composer.dev.json
@@ -3,6 +3,7 @@
         "behat/mink": "^1.11",
         "behat/mink-browserkit-driver": "^2.2",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.2",
+        "drevops/phpcs-standard": "^0.6.2",
         "drupal/coder": "^8 || ^9",
         "drush/drush": "^12 || ^13",
         "jangregor/phpstan-prophecy": "^2",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,7 @@
 
     <rule ref="Drupal"/>
     <rule ref="DrupalPractice"/>
+    <rule ref="DrevOps"/>
     <rule ref="PHPCompatibility"/>
     <rule ref="Generic.PHP.RequireStrictTypes"/>
 

--- a/rector.php
+++ b/rector.php
@@ -41,6 +41,10 @@ use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
+  ->withPaths([
+    'web/modules/custom',
+    'web/themes/custom',
+  ])
   ->withSkip([
     // Specific rules to skip based on project coding standards.
     CatchExceptionNameMatchingTypeRector::class,
@@ -80,12 +84,12 @@ return RectorConfig::configure()
   ->withPhpSets(php82: TRUE)
   // Code quality improvement sets.
   ->withPreparedSets(
+    deadCode: TRUE,
     codeQuality: TRUE,
     codingStyle: TRUE,
-    deadCode: TRUE,
-    naming: TRUE,
-    privatization: TRUE,
     typeDeclarations: TRUE,
+    privatization: TRUE,
+    naming: TRUE,
   )
   // Drupal-specific deprecation fixes.
   ->withSets([

--- a/rector.php
+++ b/rector.php
@@ -41,10 +41,6 @@ use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 
 return RectorConfig::configure()
-  ->withPaths([
-    'web/modules/custom',
-    'web/themes/custom',
-  ])
   ->withSkip([
     // Specific rules to skip based on project coding standards.
     CatchExceptionNameMatchingTypeRector::class,
@@ -84,12 +80,12 @@ return RectorConfig::configure()
   ->withPhpSets(php82: TRUE)
   // Code quality improvement sets.
   ->withPreparedSets(
-    deadCode: TRUE,
     codeQuality: TRUE,
     codingStyle: TRUE,
-    typeDeclarations: TRUE,
-    privatization: TRUE,
+    deadCode: TRUE,
     naming: TRUE,
+    privatization: TRUE,
+    typeDeclarations: TRUE,
   )
   // Drupal-specific deprecation fixes.
   ->withSets([
@@ -102,14 +98,14 @@ return RectorConfig::configure()
   ])
   // Configure Drupal autoloading.
   ->withAutoloadPaths((function (): array {
-    $drupalFinder = new DrupalFinderComposerRuntime();
-    $drupalRoot = $drupalFinder->getDrupalRoot();
+    $drupal_finder = new DrupalFinderComposerRuntime();
+    $drupal_root = $drupal_finder->getDrupalRoot();
 
     return [
-      $drupalRoot . '/core',
-      $drupalRoot . '/modules',
-      $drupalRoot . '/themes',
-      $drupalRoot . '/profiles',
+      $drupal_root . '/core',
+      $drupal_root . '/modules',
+      $drupal_root . '/themes',
+      $drupal_root . '/profiles',
     ];
   })())
   // Drupal file extensions.

--- a/src/Commands/GeneratedContentCommands.php
+++ b/src/Commands/GeneratedContentCommands.php
@@ -51,12 +51,12 @@ class GeneratedContentCommands extends DrushCommands {
   public function createContent(string $entity_type, string $bundle, int $total): void {
     $this->loggerChannelFactory->get('generated_content')->info('Generate content operations started.');
 
-    $batchBuilder = new BatchBuilder();
+    $batch_builder = new BatchBuilder();
     $batch_id = 1;
 
     for ($count = 0; $count < $total;) {
       $count += 50;
-      $batchBuilder->addOperation('\Drupal\generated_content\GeneratedContentBatchService::processItem', [
+      $batch_builder->addOperation('\Drupal\generated_content\GeneratedContentBatchService::processItem', [
         $batch_id,
         $entity_type,
         $bundle,
@@ -66,7 +66,7 @@ class GeneratedContentCommands extends DrushCommands {
       $batch_id++;
     }
 
-    $batchBuilder
+    $batch_builder
       ->setTitle($this->t('Creating generated content for @entity_type @bundle (@total items in @batches batches)', [
         '@entity_type' => $entity_type,
         '@bundle' => $bundle,
@@ -76,7 +76,7 @@ class GeneratedContentCommands extends DrushCommands {
       ->setFinishCallback('\Drupal\generated_content\GeneratedContentBatchService::processItemFinished')
       ->setErrorMessage($this->t('Batch has encountered an error'));
 
-    batch_set($batchBuilder->toArray());
+    batch_set($batch_builder->toArray());
     drush_backend_batch_process();
 
     $this->loggerChannelFactory->get('generated_content')->info('Batch operations finished.');

--- a/tests/src/Traits/GeneratedContentTestMockTrait.php
+++ b/tests/src/Traits/GeneratedContentTestMockTrait.php
@@ -34,10 +34,10 @@ trait GeneratedContentTestMockTrait {
    */
   protected static function callProtectedMethod($object, string $method, array $args = []) {
     $class = new \ReflectionClass(is_object($object) ? get_class($object) : $object);
-    $reflectionMethod = $class->getMethod($method);
-    $object = $reflectionMethod->isStatic() || is_string($object) ? NULL : $object;
+    $reflection_method = $class->getMethod($method);
+    $object = $reflection_method->isStatic() || is_string($object) ? NULL : $object;
 
-    return $reflectionMethod->invokeArgs($object, $args);
+    return $reflection_method->invokeArgs($object, $args);
   }
 
   /**


### PR DESCRIPTION
## Summary

Updates the `drupal_extension_scaffold` infrastructure from v4.15.1 to v4.15.2. The scaffold change introduces a new `drevops/phpcs-standard` PHPCS ruleset that enforces snake_case naming for local variables. This PR applies the scaffold update and adds the project-level adjustments needed to keep the build, linting, and tests working correctly in this repository.

## Changes

### Scaffold update (4.15.1 -> 4.15.2)

- `composer.dev.json`: added `drevops/phpcs-standard ^0.6.2` dependency
- `phpcs.xml`: added `<rule ref="DrevOps"/>` after the existing Drupal and DrupalPractice rules
- `rector.php`: snake_cased `$drupalFinder` / `$drupalRoot` local variables to satisfy the new naming rule

### Project-level adjustments

- `rector.php`: restored `->withPaths([web/modules/custom, web/themes/custom])` because Rector 2.x (locked via `palantirnet/drupal-rector`) errors with "Provide paths in Rector config" when paths are absent - the scaffold removal assumed Rector 1.x semantics
- `src/Commands/GeneratedContentCommands.php`: renamed `$batchBuilder` to `$batch_builder` (4 occurrences) to comply with the new `DrevOps.NamingConventions.LocalVariableNaming.NotSnakeCase` rule
- `tests/src/Traits/GeneratedContentTestMockTrait.php`: renamed `$reflectionMethod` to `$reflection_method` (3 occurrences) for the same reason
