### PR TITLE
Increased PHPUnit coverage, extracted 'buildBatch()', and fixed '@batches' off-by-one.

### DIFF
--- a/src/Commands/GeneratedContentCommands.php
+++ b/src/Commands/GeneratedContentCommands.php
@@ -51,6 +51,33 @@ class GeneratedContentCommands extends DrushCommands {
   public function createContent(string $entity_type, string $bundle, int $total): void {
     $this->loggerChannelFactory->get('generated_content')->info('Generate content operations started.');
 
+    $batch_builder = $this->buildBatch($entity_type, $bundle, $total);
+
+    batch_set($batch_builder->toArray());
+    drush_backend_batch_process();
+
+    $this->loggerChannelFactory->get('generated_content')->info('Batch operations finished.');
+  }
+
+  /**
+   * Build the BatchBuilder for a create-content run.
+   *
+   * Chunks the total into 50-item operations, each dispatched to
+   * GeneratedContentBatchService::processItem. Extracted from
+   * createContent() so it can be unit-tested without invoking the
+   * global batch_set() / drush_backend_batch_process() functions.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param string $bundle
+   *   Entity bundle.
+   * @param int $total
+   *   Number of items to create.
+   *
+   * @return \Drupal\Core\Batch\BatchBuilder
+   *   Configured batch builder.
+   */
+  protected function buildBatch(string $entity_type, string $bundle, int $total): BatchBuilder {
     $batch_builder = new BatchBuilder();
     $batch_id = 1;
 
@@ -66,7 +93,7 @@ class GeneratedContentCommands extends DrushCommands {
       $batch_id++;
     }
 
-    $batch_builder
+    return $batch_builder
       ->setTitle($this->t('Creating generated content for @entity_type @bundle (@total items in @batches batches)', [
         '@entity_type' => $entity_type,
         '@bundle' => $bundle,
@@ -75,11 +102,6 @@ class GeneratedContentCommands extends DrushCommands {
       ]))
       ->setFinishCallback('\Drupal\generated_content\GeneratedContentBatchService::processItemFinished')
       ->setErrorMessage($this->t('Batch has encountered an error'));
-
-    batch_set($batch_builder->toArray());
-    drush_backend_batch_process();
-
-    $this->loggerChannelFactory->get('generated_content')->info('Batch operations finished.');
   }
 
 }

--- a/src/Commands/GeneratedContentCommands.php
+++ b/src/Commands/GeneratedContentCommands.php
@@ -98,7 +98,7 @@ class GeneratedContentCommands extends DrushCommands {
         '@entity_type' => $entity_type,
         '@bundle' => $bundle,
         '@total' => $total,
-        '@batches' => $batch_id,
+        '@batches' => $batch_id - 1,
       ]))
       ->setFinishCallback('\Drupal\generated_content\GeneratedContentBatchService::processItemFinished')
       ->setErrorMessage($this->t('Batch has encountered an error'));

--- a/src/Helpers/GeneratedContentHelper.php
+++ b/src/Helpers/GeneratedContentHelper.php
@@ -1009,8 +1009,9 @@ class GeneratedContentHelper implements ContainerInjectionInterface {
    *
    * @param string $string
    *   String to process.
-   * @param array<string, string> $replacements
+   * @param array<string, mixed> $replacements
    *   Array of replacements with keys as tokens and values as replacements.
+   *   Non-scalar values are silently skipped.
    * @param callable|null $cb
    *   Optional callback to process values before replacement. The callback
    *   receives a value as it was passed in $replacements and must return

--- a/tests/fixtures/variations/01.gc_test_helper.inc
+++ b/tests/fixtures/variations/01.gc_test_helper.inc
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @file
+ * Fixture functions for GeneratedContentHelperVariationTest::variationFetchAll.
+ *
+ * The unique gc_test_var_ prefix prevents collisions with any
+ * user-defined functions PHPUnit may load from Drupal core or contrib
+ * before the test method runs.
+ */
+
+declare(strict_types=1);
+
+/**
+ * First variation contributor.
+ *
+ * @return array<array<string, string>>
+ *   Variations.
+ */
+function gc_test_var_one(): array {
+  return [
+    ['title' => 'one-a'],
+    ['title' => 'one-b'],
+  ];
+}
+
+/**
+ * Second variation contributor.
+ *
+ * @return array<array<string, string>>
+ *   Variations.
+ */
+function gc_test_var_two(): array {
+  return [
+    ['title' => 'two-a'],
+  ];
+}
+
+/**
+ * A contributor that returns an empty array (must be skipped).
+ *
+ * @return array<mixed>
+ *   Empty variations.
+ */
+function gc_test_var_empty(): array {
+  return [];
+}
+
+/**
+ * Post-process callback: tag every variation with a marker.
+ *
+ * @param array<array<string, string>> $variations
+ *   Raw variations.
+ *
+ * @return array<array<string, string>>
+ *   Post-processed variations.
+ */
+function gc_test_var_post_process(array $variations): array {
+  foreach ($variations as &$variation) {
+    $variation['post_processed'] = 'yes';
+  }
+
+  return $variations;
+}

--- a/tests/src/Kernel/GeneratedContentBatchServiceTest.php
+++ b/tests/src/Kernel/GeneratedContentBatchServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\generated_content\GeneratedContentBatchService;
+use Drupal\generated_content\GeneratedContentRepository;
+
+/**
+ * Tests the GeneratedContentBatchService static batch callbacks.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\GeneratedContentBatchService
+ */
+class GeneratedContentBatchServiceTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * Tests that create() returns an instance built from the container.
+   */
+  public function testCreate(): void {
+    $service = GeneratedContentBatchService::create($this->container);
+
+    $this->assertInstanceOf(GeneratedContentBatchService::class, $service);
+    $this->assertInstanceOf(ContainerInjectionInterface::class, $service);
+  }
+
+  /**
+   * Tests that processItem() composes the progress message.
+   *
+   * @param int $batch_id
+   *   Batch id.
+   * @param string $entity_type
+   *   Entity type.
+   * @param string $bundle
+   *   Bundle.
+   * @param int $total
+   *   Total.
+   * @param int $current
+   *   Current.
+   * @param string $expected
+   *   Expected message.
+   *
+   * @dataProvider dataProviderProcessItemMessage
+   */
+  public function testProcessItemMessage(int $batch_id, string $entity_type, string $bundle, int $total, int $current, string $expected): void {
+    $context = [];
+
+    GeneratedContentBatchService::processItem($batch_id, $entity_type, $bundle, $total, $current, $context);
+
+    $this->assertSame($expected, $context['message']);
+  }
+
+  /**
+   * Data provider for testProcessItemMessage().
+   *
+   * @return array<string, array<mixed>>
+   *   Provider data.
+   */
+  public static function dataProviderProcessItemMessage(): array {
+    return [
+      'simple progress' => [
+        1, 'node', 'page', 5, 1,
+        'Running batch "1" for node page (1 of 5).',
+      ],
+      'final iteration' => [
+        7, 'user', 'user', 50, 50,
+        'Running batch "7" for user user (50 of 50).',
+      ],
+      'large totals' => [
+        100, 'taxonomy_term', 'tags', 1000, 999,
+        'Running batch "100" for taxonomy_term tags (999 of 1000).',
+      ],
+    ];
+  }
+
+  /**
+   * Tests that processItem() routes through the repository.
+   */
+  public function testProcessItemCallsRepository(): void {
+    $repository = GeneratedContentRepository::getInstance();
+    $messenger = $this->container->get('messenger');
+    $messenger->deleteAll();
+
+    $context = [];
+    GeneratedContentBatchService::processItem(1, 'node', 'page', 1, 1, $context);
+
+    // No plugins are registered for node/page in this kernel test, so
+    // createEntities() iterates an empty info list. The repository still
+    // emits its post-create status message - that proves it was invoked.
+    $messages = $messenger->messagesByType('status');
+    $messages = array_map('strval', $messages);
+    $this->assertContains('Created all generated content.', $messages);
+
+    // Repository tracks no entities because no plugins ran.
+    $this->assertSame([], $repository->getEntities());
+  }
+
+  /**
+   * Tests processItemFinished() clears caches only on success.
+   *
+   * @param bool $success
+   *   Success flag.
+   * @param bool $expect_cleared
+   *   Whether the seeded cache entry should be cleared.
+   *
+   * @dataProvider dataProviderProcessItemFinished
+   */
+  public function testProcessItemFinished(bool $success, bool $expect_cleared): void {
+    $cache = $this->container->get('cache.data');
+    $cache->set('generated_content_test_key', 'seeded');
+    $this->assertNotFalse($cache->get('generated_content_test_key'));
+
+    GeneratedContentBatchService::processItemFinished($success, [], []);
+
+    if ($expect_cleared) {
+      $this->assertFalse($cache->get('generated_content_test_key'));
+    }
+    else {
+      $hit = $cache->get('generated_content_test_key');
+      $this->assertNotFalse($hit);
+      $this->assertSame('seeded', $hit->data);
+    }
+  }
+
+  /**
+   * Data provider for testProcessItemFinished().
+   *
+   * @return array<string, array<mixed>>
+   *   Provider data.
+   */
+  public static function dataProviderProcessItemFinished(): array {
+    return [
+      'success clears caches' => [TRUE, TRUE],
+      'failure leaves caches intact' => [FALSE, FALSE],
+    ];
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentBatchTest.php
+++ b/tests/src/Kernel/GeneratedContentBatchTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\generated_content\GeneratedContentBatch;
+
+/**
+ * Tests the GeneratedContentBatch static batch helpers.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\GeneratedContentBatch
+ */
+class GeneratedContentBatchTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * Tests that set('create') queues only createSingle operations.
+   */
+  public function testSetCreate(): void {
+    $batch = $this->captureBatchAfter('create');
+
+    $this->assertCount(2, $batch['operations']);
+    foreach ($batch['operations'] as $op) {
+      $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::createSingle', $op[0]);
+    }
+  }
+
+  /**
+   * Tests that set('remove') queues only removeSingle operations.
+   */
+  public function testSetRemove(): void {
+    $batch = $this->captureBatchAfter('remove');
+
+    $this->assertCount(2, $batch['operations']);
+    foreach ($batch['operations'] as $op) {
+      $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::removeSingle', $op[0]);
+    }
+  }
+
+  /**
+   * Tests that set('regenerate') queues remove followed by create operations.
+   */
+  public function testSetRegenerate(): void {
+    $batch = $this->captureBatchAfter('regenerate');
+
+    // 2 info items each get a remove and a create.
+    $this->assertCount(4, $batch['operations']);
+
+    // First half are removes, second half are creates.
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::removeSingle', $batch['operations'][0][0]);
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::removeSingle', $batch['operations'][1][0]);
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::createSingle', $batch['operations'][2][0]);
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::createSingle', $batch['operations'][3][0]);
+  }
+
+  /**
+   * Tests createSingle() initialises sandbox/results when missing.
+   *
+   * Repository::createSingle() requires a real plugin and will throw
+   * for our placeholder plugin id - the throw lands after the init
+   * block so the assertion below pins the init contract only. Full
+   * increment behaviour is tested via removeSingle(), which has no
+   * plugin dependency.
+   */
+  public function testCreateSingleInitialisesContext(): void {
+    $info = ['entity_type' => 'node', 'bundle' => 'page', '#plugin_id' => 'missing_plugin', '#tracking' => TRUE];
+    $context = [];
+
+    try {
+      GeneratedContentBatch::createSingle($info, 4, $context);
+    }
+    catch (\Throwable $e) {
+      // Repository will throw because the plugin ID is missing - the
+      // pre-throw context setup is what we care about.
+    }
+
+    $this->assertSame(0, $context['sandbox']['count']);
+    $this->assertSame(0, $context['results']['count']);
+  }
+
+  /**
+   * Tests removeSingle() advances the sandbox count and writes the message.
+   *
+   * Repository::removeSingle() does not require a plugin - it issues
+   * an internal database delete against the tracking table - so this
+   * test exercises the full counter-and-message path.
+   */
+  public function testRemoveSingleAdvancesContext(): void {
+    $info = ['entity_type' => 'node', 'bundle' => 'page'];
+    $context = [
+      'sandbox' => ['count' => 1],
+      'results' => ['count' => 1],
+    ];
+
+    GeneratedContentBatch::removeSingle($info, 2, $context);
+
+    $this->assertSame(2, $context['sandbox']['count']);
+    $this->assertSame(2, $context['results']['count']);
+    $this->assertEquals(1, $context['finished']);
+    $this->assertStringContainsString('Deleting', (string) $context['message']);
+    $this->assertStringContainsString('node', (string) $context['message']);
+    $this->assertStringContainsString('page', (string) $context['message']);
+  }
+
+  /**
+   * Tests removeSingle() initialises sandbox/results and increments.
+   */
+  public function testRemoveSingleInitialisesContext(): void {
+    $info = ['entity_type' => 'node', 'bundle' => 'page'];
+    $context = [];
+
+    GeneratedContentBatch::removeSingle($info, 1, $context);
+
+    // Initialised at 0 then incremented by 1.
+    $this->assertSame(1, $context['sandbox']['count']);
+    $this->assertSame(1, $context['results']['count']);
+    $this->assertEquals(1, $context['finished']);
+  }
+
+  /**
+   * Tests finished(TRUE, ...) clears caches and posts a success message.
+   */
+  public function testFinishedSuccess(): void {
+    $cache = $this->container->get('cache.data');
+    $cache->set('generated_content_test_seed', 'seeded');
+    $this->assertNotFalse($cache->get('generated_content_test_seed'));
+
+    /** @var \Drupal\Core\Messenger\MessengerInterface $messenger */
+    $messenger = $this->container->get('messenger');
+    $messenger->deleteAll();
+
+    GeneratedContentBatch::finished(TRUE, ['count' => 5], []);
+
+    $this->assertFalse($cache->get('generated_content_test_seed'));
+    $messages = array_map('strval', $messenger->messagesByType('status'));
+    $this->assertNotEmpty($messages);
+    $combined = implode("\n", $messages);
+    $this->assertStringContainsString('5', $combined);
+  }
+
+  /**
+   * Tests finished(FALSE, ...) posts the error message and leaves caches alone.
+   */
+  public function testFinishedFailure(): void {
+    $cache = $this->container->get('cache.data');
+    $cache->set('generated_content_test_seed', 'seeded');
+
+    /** @var \Drupal\Core\Messenger\MessengerInterface $messenger */
+    $messenger = $this->container->get('messenger');
+    $messenger->deleteAll();
+
+    GeneratedContentBatch::finished(FALSE, [], []);
+
+    $hit = $cache->get('generated_content_test_seed');
+    $this->assertNotFalse($hit);
+    $this->assertSame('seeded', $hit->data);
+
+    $messages = array_map('strval', $messenger->messagesByType('status'));
+    $combined = implode("\n", $messages);
+    $this->assertStringContainsString('error', strtolower($combined));
+  }
+
+  /**
+   * Call GeneratedContentBatch::set() and return the queued batch array.
+   */
+  protected function captureBatchAfter(string $op): array {
+    $info_items = [
+      ['entity_type' => 'node', 'bundle' => 'page'],
+      ['entity_type' => 'user', 'bundle' => 'user'],
+    ];
+
+    $batch =& batch_get();
+    $batch = NULL;
+
+    GeneratedContentBatch::set($op, $info_items, 1);
+
+    $queued =& batch_get();
+    $this->assertIsArray($queued);
+    $this->assertArrayHasKey('sets', $queued);
+    $this->assertNotEmpty($queued['sets']);
+
+    return end($queued['sets']);
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentExample1PluginsTest.php
+++ b/tests/src/Kernel/GeneratedContentExample1PluginsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginInterface;
+use Drupal\generated_content_example1\Plugin\GeneratedContent\TaxonomyTermTags;
+
+/**
+ * Tests the example1 plugins that are not exercised elsewhere.
+ *
+ * The example1 TaxonomyTermTags plugin is an intentional empty
+ * placeholder - the README notes that example2 takes precedence and
+ * actually generates terms. This test pins the placeholder's
+ * behaviour so it stays empty.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content_example1\Plugin\GeneratedContent\TaxonomyTermTags
+ */
+class GeneratedContentExample1PluginsTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'file',
+    'taxonomy',
+    'generated_content',
+    'generated_content_example1',
+  ];
+
+  /**
+   * Tests that example1 TaxonomyTermTags::generate() returns an empty array.
+   */
+  public function testTaxonomyTermTagsGenerateIsEmpty(): void {
+    /** @var \Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginManager $manager */
+    $manager = $this->container->get('plugin.manager.generated_content');
+
+    /** @var \Drupal\generated_content_example1\Plugin\GeneratedContent\TaxonomyTermTags $plugin */
+    $plugin = $manager->createInstance('example1_taxonomy_term_tags');
+
+    $this->assertInstanceOf(TaxonomyTermTags::class, $plugin);
+    $this->assertInstanceOf(GeneratedContentPluginInterface::class, $plugin);
+    $this->assertSame([], $plugin->generate());
+  }
+
+  /**
+   * Tests that the plugin exposes the expected metadata.
+   */
+  public function testTaxonomyTermTagsMetadata(): void {
+    /** @var \Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginManager $manager */
+    $manager = $this->container->get('plugin.manager.generated_content');
+
+    /** @var \Drupal\generated_content_example1\Plugin\GeneratedContent\TaxonomyTermTags $plugin */
+    $plugin = $manager->createInstance('example1_taxonomy_term_tags');
+
+    $this->assertSame('taxonomy_term', $plugin->getEntityType());
+    $this->assertSame('tags', $plugin->getBundle());
+    $this->assertSame(11, $plugin->getWeight());
+    $this->assertTrue($plugin->getTracking());
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentFormTest.php
+++ b/tests/src/Kernel/GeneratedContentFormTest.php
@@ -111,7 +111,7 @@ class GeneratedContentFormTest extends GeneratedContentKernelTestBase {
    * @param string $expected_method
    *   Repository method that must be invoked.
    *
-   * @dataProvider dataProviderSubmitForm
+   * @dataProvider dataProviderSubmitFormDispatch
    */
   public function testSubmitFormDispatch(string $button, string $expected_method): void {
     $info_item = [
@@ -146,7 +146,7 @@ class GeneratedContentFormTest extends GeneratedContentKernelTestBase {
    * @return array<string, array<string>>
    *   Provider data.
    */
-  public static function dataProviderSubmitForm(): array {
+  public static function dataProviderSubmitFormDispatch(): array {
     return [
       'generate button calls createBatch' => ['generate', 'createBatch'],
       'delete button calls removeBatch' => ['delete', 'removeBatch'],

--- a/tests/src/Kernel/GeneratedContentFormTest.php
+++ b/tests/src/Kernel/GeneratedContentFormTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Form\FormState;
+use Drupal\generated_content\Form\GeneratedContentForm;
+use Drupal\generated_content\GeneratedContentRepository;
+
+/**
+ * Tests the GeneratedContentForm admin form.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Form\GeneratedContentForm
+ */
+class GeneratedContentFormTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'file',
+    'taxonomy',
+    'generated_content',
+  ];
+
+  /**
+   * Tests getFormId() returns a stable identifier.
+   */
+  public function testGetFormId(): void {
+    $form = $this->buildFormInstance();
+
+    $this->assertSame('generated_content_form', $form->getFormId());
+  }
+
+  /**
+   * Tests create() returns a configured form instance.
+   */
+  public function testCreate(): void {
+    $form = GeneratedContentForm::create($this->container);
+
+    $this->assertInstanceOf(GeneratedContentForm::class, $form);
+    $this->assertInstanceOf(ContainerInjectionInterface::class, $form);
+  }
+
+  /**
+   * Tests buildForm() with no plugins shows the empty state and no buttons.
+   */
+  public function testBuildFormEmpty(): void {
+    $form_array = [];
+    $form_state = new FormState();
+
+    $form = $this->buildFormInstance();
+    $built = $form->buildForm($form_array, $form_state);
+
+    $this->assertArrayHasKey('table', $built);
+    $this->assertSame('tableselect', $built['table']['#type']);
+    $this->assertSame([], $built['table']['#options']);
+    $this->assertArrayNotHasKey('generate', $built);
+    $this->assertArrayNotHasKey('delete', $built);
+    $this->assertArrayNotHasKey('regenerate', $built);
+    $this->assertNotEmpty((string) $built['table']['#empty']);
+  }
+
+  /**
+   * Tests buildForm() with plugins exposes the action buttons.
+   */
+  public function testBuildFormWithPlugins(): void {
+    $repository = $this->createMock(GeneratedContentRepository::class);
+    $repository->method('getInfo')->willReturn([
+      'user__user' => [
+        'entity_type' => 'user',
+        'bundle' => 'user',
+        '#weight' => 1,
+        '#tracking' => TRUE,
+        '#module' => 'test',
+        '#plugin_id' => 'test_user',
+      ],
+    ]);
+    $repository->method('getEntities')->willReturn([1, 2]);
+
+    $form = new GeneratedContentForm($repository);
+    $form->setStringTranslation($this->container->get('string_translation'));
+
+    $form_array = [];
+    $form_state = new FormState();
+    $built = $form->buildForm($form_array, $form_state);
+
+    $this->assertArrayHasKey('table', $built);
+    $this->assertCount(1, $built['table']['#options']);
+    $this->assertArrayHasKey('actions_description', $built);
+    $this->assertArrayHasKey('generate', $built);
+    $this->assertArrayHasKey('delete', $built);
+    $this->assertArrayHasKey('regenerate', $built);
+    $this->assertSame('generate', $built['generate']['#name']);
+    $this->assertSame('delete', $built['delete']['#name']);
+    $this->assertSame('regenerate', $built['regenerate']['#name']);
+  }
+
+  /**
+   * Tests submitForm() dispatches each button to the matching repository call.
+   *
+   * @param string $button
+   *   Triggering button name.
+   * @param string $expected_method
+   *   Repository method that must be invoked.
+   *
+   * @dataProvider dataProviderSubmitForm
+   */
+  public function testSubmitFormDispatch(string $button, string $expected_method): void {
+    $info_item = [
+      'entity_type' => 'user',
+      'bundle' => 'user',
+      '#weight' => 1,
+      '#tracking' => TRUE,
+      '#module' => 'test',
+      '#plugin_id' => 'test_user',
+    ];
+
+    $repository = $this->createMock(GeneratedContentRepository::class);
+    $repository->method('getInfo')->willReturn(['user__user' => $info_item]);
+    $repository->method('findInfo')->willReturn($info_item);
+    $repository->expects($this->once())
+      ->method($expected_method)
+      ->with([$info_item]);
+
+    $form = new GeneratedContentForm($repository);
+
+    $form_state = new FormState();
+    $form_state->setValue('table', ['user__user' => 'user__user']);
+    $form_state->setTriggeringElement(['#name' => $button]);
+
+    $form_array = [];
+    $form->submitForm($form_array, $form_state);
+  }
+
+  /**
+   * Data provider for testSubmitFormDispatch().
+   *
+   * @return array<string, array<string>>
+   *   Provider data.
+   */
+  public static function dataProviderSubmitForm(): array {
+    return [
+      'generate button calls createBatch' => ['generate', 'createBatch'],
+      'delete button calls removeBatch' => ['delete', 'removeBatch'],
+      'regenerate button calls regenerateBatch' => ['regenerate', 'regenerateBatch'],
+    ];
+  }
+
+  /**
+   * Tests submitForm() with an unknown button name is a no-op.
+   */
+  public function testSubmitFormUnknownButton(): void {
+    $repository = $this->createMock(GeneratedContentRepository::class);
+    $repository->method('getInfo')->willReturn([]);
+    $repository->expects($this->never())->method('createBatch');
+    $repository->expects($this->never())->method('removeBatch');
+    $repository->expects($this->never())->method('regenerateBatch');
+
+    $form = new GeneratedContentForm($repository);
+    $form_state = new FormState();
+    $form_state->setValue('table', []);
+    $form_state->setTriggeringElement(['#name' => 'cancel']);
+
+    $form_array = [];
+    $form->submitForm($form_array, $form_state);
+  }
+
+  /**
+   * Tests entityInfoToLink() for each supported entity type.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param string|null $bundle
+   *   Bundle.
+   * @param string $must_contain
+   *   Substring the returned link/string must include.
+   *
+   * @dataProvider dataProviderEntityInfoToLink
+   */
+  public function testEntityInfoToLink(string $entity_type, ?string $bundle, string $must_contain): void {
+    $form = $this->buildFormInstance();
+    $result = (string) self::callProtectedMethod($form, 'entityInfoToLink', [$entity_type, $bundle]);
+
+    $this->assertStringContainsString($must_contain, $result);
+  }
+
+  /**
+   * Data provider for testEntityInfoToLink().
+   *
+   * @return array<string, array<mixed>>
+   *   Provider data.
+   */
+  public static function dataProviderEntityInfoToLink(): array {
+    return [
+      'node entity-only renders as label' => ['node', NULL, 'node'],
+      'node with bundle renders bundle' => ['node', 'page', 'page'],
+      'file path link' => ['file', NULL, 'file'],
+      'media path link' => ['media', NULL, 'media'],
+      'media with bundle renders bundle' => ['media', 'image', 'image'],
+      'taxonomy term entity-only renders entity label' => ['taxonomy_term', NULL, 'taxonomy_term'],
+      'user collection link' => ['user', NULL, 'user'],
+      'unknown entity type passes through' => ['custom', NULL, 'custom'],
+    ];
+  }
+
+  /**
+   * Build a real GeneratedContentForm wired against the container.
+   */
+  protected function buildFormInstance(): GeneratedContentForm {
+    return GeneratedContentForm::create($this->container);
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentHelperRandomTest.php
+++ b/tests/src/Kernel/GeneratedContentHelperRandomTest.php
@@ -470,14 +470,14 @@ class GeneratedContentHelperRandomTest extends GeneratedContentKernelTestBase {
   }
 
   /**
-   * Test randomDisperse() places every filler into the resulting array.
+   * Test randomDisperse() exercises both splice paths.
    *
    * Implementation uses array_splice($scope, rand(0, count($scope)),
    * 1, $filler) - when rand() returns count($scope) the splice
-   * appends (no removal), otherwise it replaces one element. So the
-   * final size is non-deterministic in [count(scope),
-   * count(scope) + count(fillers)]. We assert the bounds and that
-   * every filler is present.
+   * appends; otherwise it replaces an element. Either path can
+   * overwrite a filler that an earlier iteration just placed, so we
+   * cannot assert that every filler survives in the final array.
+   * We assert size bounds and presence of at least one filler.
    */
   public function testRandomDisperse(): void {
     /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
@@ -490,8 +490,22 @@ class GeneratedContentHelperRandomTest extends GeneratedContentKernelTestBase {
 
     $this->assertGreaterThanOrEqual(count($scope), count($result));
     $this->assertLessThanOrEqual(count($scope) + count($fillers), count($result));
-    $this->assertContains('X', $result);
-    $this->assertContains('Y', $result);
+    $this->assertNotEmpty(array_intersect($fillers, $result));
+  }
+
+  /**
+   * Test randomDisperse() with a single filler always places it.
+   *
+   * One iteration cannot overwrite itself, so the single filler is
+   * always present in the result.
+   */
+  public function testRandomDisperseSingleFiller(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $result = $helper::randomDisperse(['a', 'b', 'c'], ['Z']);
+
+    $this->assertContains('Z', $result);
   }
 
   /**

--- a/tests/src/Kernel/GeneratedContentHelperRandomTest.php
+++ b/tests/src/Kernel/GeneratedContentHelperRandomTest.php
@@ -322,4 +322,204 @@ class GeneratedContentHelperRandomTest extends GeneratedContentKernelTestBase {
     $this->assertTrue(in_array($value, $array));
   }
 
+  /**
+   * Test randomArrayItem() with an empty haystack.
+   */
+  public function testRandomArrayItemEmpty(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->assertFalse($helper::randomArrayItem([]));
+  }
+
+  /**
+   * Test randomArrayItems() with zero count.
+   */
+  public function testRandomArrayItemsZero(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->assertSame([], $helper::randomArrayItems(['a', 'b', 'c'], 0));
+  }
+
+  /**
+   * Test randomTimestamp() default and explicit ranges.
+   */
+  public function testRandomTimestamp(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $default = $helper::randomTimestamp();
+    $now = time();
+    $one_year = 60 * 60 * 24 * 366;
+    $this->assertGreaterThanOrEqual($now - $one_year, $default);
+    $this->assertLessThanOrEqual($now + $one_year, $default);
+
+    $explicit = $helper::randomTimestamp('-1day', '+1day');
+    $this->assertGreaterThanOrEqual($now - 60 * 60 * 24 - 1, $explicit);
+    $this->assertLessThanOrEqual($now + 60 * 60 * 24 + 1, $explicit);
+  }
+
+  /**
+   * Test randomTimestamp() rejects invalid "from".
+   */
+  public function testRandomTimestampInvalidFrom(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('From value is not valid.');
+    $helper::randomTimestamp('not-a-date');
+  }
+
+  /**
+   * Test randomTimestamp() rejects invalid "to".
+   */
+  public function testRandomTimestampInvalidTo(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('To value is not valid.');
+    $helper::randomTimestamp('-1year', 'also-not-a-date');
+  }
+
+  /**
+   * Test randomDate() default behaviour and explicit format.
+   */
+  public function testRandomDate(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $date = $helper::randomDate();
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $date);
+
+    $date_with_time = $helper::randomDate('now', 'now', TRUE);
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00$/', $date_with_time);
+
+    $explicit_range = $helper::randomDate('2020-01-01', '2020-12-31');
+    $this->assertGreaterThanOrEqual('2020-01-01', $explicit_range);
+    $this->assertLessThanOrEqual('2020-12-31', $explicit_range);
+  }
+
+  /**
+   * Test randomDate() rejects invalid "start".
+   */
+  public function testRandomDateInvalidStart(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Start value is not valid.');
+    $helper::randomDate('garbage', 'now');
+  }
+
+  /**
+   * Test randomDate() rejects invalid "finish".
+   */
+  public function testRandomDateInvalidFinish(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Finish value is not valid.');
+    $helper::randomDate('now', 'garbage');
+  }
+
+  /**
+   * Test randomDateRange() default format and value/end_value ordering.
+   */
+  public function testRandomDateRange(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $range = $helper::randomDateRange('2020-01-01', '2020-12-31');
+    $this->assertArrayHasKey('value', $range);
+    $this->assertArrayHasKey('end_value', $range);
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $range['value']);
+    $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $range['end_value']);
+    $this->assertLessThanOrEqual($range['end_value'], $range['value']);
+
+    $custom = $helper::randomDateRange('2020-01-01', '2020-12-31', 'Y');
+    $this->assertSame('2020', $custom['value']);
+    $this->assertSame('2020', $custom['end_value']);
+  }
+
+  /**
+   * Test randomDateRange() rejects invalid "start".
+   */
+  public function testRandomDateRangeInvalidStart(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Start value is not valid.');
+    $helper::randomDateRange('garbage', '2020-12-31');
+  }
+
+  /**
+   * Test randomDateRange() rejects invalid "finish".
+   */
+  public function testRandomDateRangeInvalidFinish(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('Finish value is not valid.');
+    $helper::randomDateRange('2020-01-01', 'garbage');
+  }
+
+  /**
+   * Test randomDisperse() places every filler into the resulting array.
+   *
+   * Implementation uses array_splice($scope, rand(0, count($scope)),
+   * 1, $filler) - when rand() returns count($scope) the splice
+   * appends (no removal), otherwise it replaces one element. So the
+   * final size is non-deterministic in [count(scope),
+   * count(scope) + count(fillers)]. We assert the bounds and that
+   * every filler is present.
+   */
+  public function testRandomDisperse(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $scope = ['a', 'b', 'c', 'd'];
+    $fillers = ['X', 'Y'];
+
+    $result = $helper::randomDisperse($scope, $fillers);
+
+    $this->assertGreaterThanOrEqual(count($scope), count($result));
+    $this->assertLessThanOrEqual(count($scope) + count($fillers), count($result));
+    $this->assertContains('X', $result);
+    $this->assertContains('Y', $result);
+  }
+
+  /**
+   * Test randomDisperse() with empty fillers leaves the scope unchanged.
+   */
+  public function testRandomDisperseEmptyFillers(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $scope = ['a', 'b', 'c'];
+    $this->assertSame($scope, $helper::randomDisperse($scope, []));
+  }
+
+  /**
+   * Test randomBool() with default skew returns booleans.
+   */
+  public function testRandomBoolDistribution(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $values = [];
+    for ($i = 0; $i < 50; $i++) {
+      $values[] = $helper::randomBool();
+    }
+
+    foreach ($values as $value) {
+      $this->assertIsBool($value);
+    }
+  }
+
 }

--- a/tests/src/Kernel/GeneratedContentHelperTermTreeTest.php
+++ b/tests/src/Kernel/GeneratedContentHelperTermTreeTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\generated_content\Helpers\GeneratedContentHelper;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Tests saveTermTree() and getTermsAtDepth() helpers.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Helpers\GeneratedContentHelper::saveTermTree
+ * @covers \Drupal\generated_content\Helpers\GeneratedContentHelper::getTermsAtDepth
+ */
+class GeneratedContentHelperTermTreeTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'file',
+    'text',
+    'taxonomy',
+    'generated_content',
+  ];
+
+  /**
+   * Vocabulary used by the tree tests.
+   */
+  protected string $vid = 'test_tree';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('taxonomy_term');
+    Vocabulary::create(['vid' => $this->vid, 'name' => 'Test Tree'])->save();
+
+    // saveTermTree() / getTermsAtDepth() use the static entityTypeManager
+    // property on the Helper - getInstance() is what populates it.
+    GeneratedContentHelper::getInstance();
+  }
+
+  /**
+   * Tests saveTermTree() with a flat list of terms.
+   */
+  public function testSaveTermTreeFlat(): void {
+    $tree = [
+      'Apples',
+      'Bananas',
+      'Cherries',
+    ];
+
+    $terms = GeneratedContentHelper::saveTermTree($this->vid, $tree);
+
+    $this->assertCount(3, $terms);
+    foreach ($terms as $term) {
+      $this->assertInstanceOf(TermInterface::class, $term);
+      $this->assertSame($this->vid, $term->bundle());
+    }
+  }
+
+  /**
+   * Tests saveTermTree() builds a nested hierarchy.
+   */
+  public function testSaveTermTreeNested(): void {
+    $tree = [
+      'Fruit' => [
+        'Apples',
+        'Bananas',
+      ],
+      'Vegetables' => [
+        'Carrots',
+      ],
+    ];
+
+    $terms = GeneratedContentHelper::saveTermTree($this->vid, $tree);
+
+    // Two parents + three children.
+    $this->assertCount(5, $terms);
+
+    // getTermsAtDepth uses loadTree under the hood.
+    $depth_zero = GeneratedContentHelper::getTermsAtDepth($this->vid, 0);
+    $depth_one = GeneratedContentHelper::getTermsAtDepth($this->vid, 1);
+
+    $this->assertCount(2, $depth_zero);
+    $this->assertCount(3, $depth_one);
+  }
+
+  /**
+   * Tests getTermsAtDepth() clamps negative depth to zero.
+   */
+  public function testGetTermsAtDepthNegative(): void {
+    GeneratedContentHelper::saveTermTree($this->vid, ['A', 'B']);
+
+    $terms = GeneratedContentHelper::getTermsAtDepth($this->vid, -5);
+
+    // -5 is treated as 0 -> root-level terms.
+    $this->assertCount(2, $terms);
+  }
+
+  /**
+   * Tests getTermsAtDepth() with load_entities=TRUE returns Term entities.
+   */
+  public function testGetTermsAtDepthLoaded(): void {
+    GeneratedContentHelper::saveTermTree($this->vid, ['Loaded']);
+
+    $terms = GeneratedContentHelper::getTermsAtDepth($this->vid, 0, TRUE);
+
+    $this->assertCount(1, $terms);
+    foreach ($terms as $term) {
+      $this->assertInstanceOf(TermInterface::class, $term);
+    }
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentHelperVariationTest.php
+++ b/tests/src/Kernel/GeneratedContentHelperVariationTest.php
@@ -179,6 +179,7 @@ class GeneratedContentHelperVariationTest extends GeneratedContentKernelTestBase
 
     $node = $helper::variationCreateNode($this->nodeTypes[0], ['status' => FALSE], 0);
 
+    $this->assertInstanceOf(NodeInterface::class, $node);
     $this->assertFalse($node->isPublished());
   }
 
@@ -202,6 +203,7 @@ class GeneratedContentHelperVariationTest extends GeneratedContentKernelTestBase
     $variation = ['status' => TRUE, 'foo' => 'bar'];
     $node = $helper::variationCreateNode($this->nodeTypes[0], $variation, 7, $callback);
 
+    $this->assertInstanceOf(NodeInterface::class, $node);
     $this->assertSame('post-processed', $node->getTitle());
     $this->assertSame($this->nodeTypes[0], $captured['bundle']);
     $this->assertSame($variation, $captured['variation']);

--- a/tests/src/Kernel/GeneratedContentHelperVariationTest.php
+++ b/tests/src/Kernel/GeneratedContentHelperVariationTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\generated_content\Helpers\GeneratedContentHelper;
+use Drupal\node\NodeInterface;
+
+/**
+ * Tests the GeneratedContentVariationTrait via GeneratedContentHelper.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Helpers\GeneratedContentVariationTrait
+ */
+class GeneratedContentHelperVariationTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * Tests variationRandomValue() expansion of NULL/array/scalar inputs.
+   */
+  public function testVariationRandomValueShapes(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $input = [
+      'null_field' => NULL,
+      'array_field' => ['x', 'y', 'z'],
+      'string_field' => 'keep me',
+      'int_field' => 42,
+      'bool_field' => TRUE,
+    ];
+
+    $result = $helper::variationRandomValue($input);
+
+    $this->assertIsBool($result['null_field']);
+    $this->assertContains($result['array_field'], ['x', 'y', 'z']);
+    $this->assertSame('keep me', $result['string_field']);
+    $this->assertSame(42, $result['int_field']);
+    $this->assertTrue($result['bool_field']);
+  }
+
+  /**
+   * Tests variationRandomValue() with an empty variation.
+   */
+  public function testVariationRandomValueEmpty(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->assertSame([], $helper::variationRandomValue([]));
+  }
+
+  /**
+   * Tests variationFormatInfo() output for each value type.
+   *
+   * @param array<mixed> $variation
+   *   Variation input.
+   * @param int $name_length
+   *   Name length argument.
+   * @param string $expected
+   *   Expected formatted string.
+   *
+   * @dataProvider dataProviderVariationFormatInfo
+   */
+  public function testVariationFormatInfo(array $variation, int $name_length, string $expected): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->assertSame($expected, $helper::variationFormatInfo($variation, $name_length));
+  }
+
+  /**
+   * Data provider for testVariationFormatInfo().
+   *
+   * @return array<string, array<mixed>>
+   *   Provider data.
+   */
+  public static function dataProviderVariationFormatInfo(): array {
+    return [
+      'truthy bool renders as Y' => [['enabled' => TRUE], 3, 'Ena: Y'],
+      'falsy null renders as N' => [['enabled' => NULL], 3, 'Ena: N'],
+      'int zero renders as N' => [['count' => 0], 3, 'Cou: N'],
+      'int non-zero renders as value' => [['count' => 7], 3, 'Cou: 7'],
+      'array renders as length' => [['tags' => ['a', 'b', 'c']], 3, 'Tag: 3'],
+      'string is trimmed to 3 chars' => [['label' => 'hello world'], 3, 'Lab: hel'],
+      'string with HTML is stripped' => [['label' => '<em>hi</em>'], 3, 'Lab: hi'],
+      'snake-cased name is collapsed' => [['my_field_name' => 'abc'], 4, 'Myfi: abc'],
+      'multiple fields are comma-joined' => [
+        ['status' => TRUE, 'count' => 2],
+        3,
+        'Sta: Y, Cou: 2',
+      ],
+    ];
+  }
+
+  /**
+   * Tests variationFetchAll() with a fixture directory of .inc files.
+   */
+  public function testVariationFetchAllWithPath(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $path = $this->fixturesPath();
+
+    $variations = $helper::variationFetchAll('gc_test_var_', $path);
+
+    // Three variations from gc_test_var_one + gc_test_var_two; the
+    // gc_test_var_empty contributor returns nothing and is skipped.
+    $this->assertCount(3, $variations);
+
+    // Post-processor tags every variation.
+    foreach ($variations as $variation) {
+      $this->assertSame('yes', $variation['post_processed']);
+    }
+  }
+
+  /**
+   * Tests variationFetchAll() against an unreadable directory.
+   */
+  public function testVariationFetchAllInvalidPath(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $this->expectException(\Exception::class);
+    $this->expectExceptionMessage('does not exist');
+    $helper::variationFetchAll('gc_test_var_', '/path/that/does/not/exist/anywhere');
+  }
+
+  /**
+   * Tests variationFetchAll() without a path - just uses defined functions.
+   *
+   * This depends on the fixture file having been included by an earlier
+   * test in this run. PHPUnit runs methods in declaration order by
+   * default and require_once side effects persist across methods, so
+   * this test calls variationFetchAll() with a NULL path after the
+   * fixture has already been loaded.
+   *
+   * @depends testVariationFetchAllWithPath
+   */
+  public function testVariationFetchAllNoPath(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    // Ensure the fixture is loaded - the @depends already guarantees
+    // testVariationFetchAllWithPath ran first, but Kernel tests reset
+    // the container per method, so re-include the file defensively.
+    require_once $this->fixturesPath() . '/01.gc_test_helper.inc';
+
+    $variations = $helper::variationFetchAll('gc_test_var_');
+
+    $this->assertCount(3, $variations);
+  }
+
+  /**
+   * Tests variationCreateNode() without a post-process callback.
+   *
+   * The test node bundles do not declare a moderation_state field so
+   * Drupal silently drops the moderation hint - the published status
+   * is the observable side-effect.
+   */
+  public function testVariationCreateNodePublished(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $node = $helper::variationCreateNode($this->nodeTypes[0], ['status' => TRUE], 0);
+
+    $this->assertInstanceOf(NodeInterface::class, $node);
+    $this->assertSame($this->nodeTypes[0], $node->bundle());
+    $this->assertSame('Node title from variation', $node->getTitle());
+    $this->assertTrue($node->isPublished());
+  }
+
+  /**
+   * Tests variationCreateNode() produces an unpublished node for status FALSE.
+   */
+  public function testVariationCreateNodeUnpublished(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $node = $helper::variationCreateNode($this->nodeTypes[0], ['status' => FALSE], 0);
+
+    $this->assertFalse($node->isPublished());
+  }
+
+  /**
+   * Tests variationCreateNode() invokes the post-process callback.
+   */
+  public function testVariationCreateNodePostprocess(): void {
+    /** @var \Drupal\generated_content\Helpers\GeneratedContentHelper $helper */
+    $helper = GeneratedContentHelper::getInstance();
+
+    $captured = [];
+    $callback = function ($node, $variation, $variation_idx) use (&$captured): void {
+      $captured = [
+        'bundle' => $node->bundle(),
+        'variation' => $variation,
+        'index' => $variation_idx,
+      ];
+      $node->setTitle('post-processed');
+    };
+
+    $variation = ['status' => TRUE, 'foo' => 'bar'];
+    $node = $helper::variationCreateNode($this->nodeTypes[0], $variation, 7, $callback);
+
+    $this->assertSame('post-processed', $node->getTitle());
+    $this->assertSame($this->nodeTypes[0], $captured['bundle']);
+    $this->assertSame($variation, $captured['variation']);
+    $this->assertSame(7, $captured['index']);
+  }
+
+  /**
+   * Absolute path to the variations fixture directory.
+   */
+  protected function fixturesPath(): string {
+    return __DIR__ . '/../../fixtures/variations';
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentPluginBaseTest.php
+++ b/tests/src/Kernel/GeneratedContentPluginBaseTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\generated_content\Kernel;
 
 use Drupal\generated_content\Helpers\GeneratedContentHelper;
+use Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase;
 use Drupal\generated_content_example2\GeneratedContentExample2Helper;
 
 /**
@@ -68,11 +69,13 @@ class GeneratedContentPluginBaseTest extends GeneratedContentKernelTestBase {
     // example1 user plugin declares weight: -100.
     $with_explicit = $this->container->get('plugin.manager.generated_content')
       ->createInstance('example1_user_user');
+    $this->assertInstanceOf(GeneratedContentPluginBase::class, $with_explicit);
     $this->assertSame(-100, $with_explicit->getWeight());
 
     // example2 node page plugin declares weight: 35.
     $other_weight = $this->container->get('plugin.manager.generated_content')
       ->createInstance('example2_node_page');
+    $this->assertInstanceOf(GeneratedContentPluginBase::class, $other_weight);
     $this->assertSame(35, $other_weight->getWeight());
   }
 
@@ -83,11 +86,13 @@ class GeneratedContentPluginBaseTest extends GeneratedContentKernelTestBase {
     // example1 user plugin declares tracking: FALSE.
     $no_tracking = $this->container->get('plugin.manager.generated_content')
       ->createInstance('example1_user_user');
+    $this->assertInstanceOf(GeneratedContentPluginBase::class, $no_tracking);
     $this->assertFalse($no_tracking->getTracking());
 
     // example1 tags plugin does not declare tracking - defaults to TRUE.
     $defaults_to_true = $this->container->get('plugin.manager.generated_content')
       ->createInstance('example1_taxonomy_term_tags');
+    $this->assertInstanceOf(GeneratedContentPluginBase::class, $defaults_to_true);
     $this->assertTrue($defaults_to_true->getTracking());
   }
 
@@ -98,6 +103,7 @@ class GeneratedContentPluginBaseTest extends GeneratedContentKernelTestBase {
     $plugin = $this->container->get('plugin.manager.generated_content')
       ->createInstance('example2_node_article');
 
+    $this->assertInstanceOf(GeneratedContentPluginBase::class, $plugin);
     $this->assertSame('node', $plugin->getEntityType());
     $this->assertSame('article', $plugin->getBundle());
   }

--- a/tests/src/Kernel/GeneratedContentPluginBaseTest.php
+++ b/tests/src/Kernel/GeneratedContentPluginBaseTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\generated_content\Helpers\GeneratedContentHelper;
+use Drupal\generated_content_example2\GeneratedContentExample2Helper;
+
+/**
+ * Tests GeneratedContentPluginBase via the example1 and example2 plugins.
+ *
+ * The base class methods (getEntityType, getBundle, getWeight,
+ * getTracking, resolveHelper) are exercised through real plugin
+ * instances obtained from the plugin manager. example1 plugins do
+ * not declare a `helper:` attribute - they should resolve the base
+ * helper; example2 plugins declare a custom helper class.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Plugin\GeneratedContent\GeneratedContentPluginBase
+ */
+class GeneratedContentPluginBaseTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'node',
+    'file',
+    'taxonomy',
+    'generated_content',
+    'generated_content_example1',
+    'generated_content_example2',
+  ];
+
+  /**
+   * Tests the default-helper branch of resolveHelper().
+   */
+  public function testResolveHelperDefault(): void {
+    $plugin = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example1_taxonomy_term_tags');
+
+    $helper = self::callProtectedMethod($plugin, 'resolveHelper');
+
+    $this->assertInstanceOf(GeneratedContentHelper::class, $helper);
+    $this->assertNotInstanceOf(GeneratedContentExample2Helper::class, $helper);
+  }
+
+  /**
+   * Tests the custom-helper branch of resolveHelper().
+   */
+  public function testResolveHelperCustom(): void {
+    $plugin = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example2_node_page');
+
+    $helper = self::callProtectedMethod($plugin, 'resolveHelper');
+
+    $this->assertInstanceOf(GeneratedContentExample2Helper::class, $helper);
+  }
+
+  /**
+   * Tests getWeight() with default and explicit values.
+   */
+  public function testGetWeight(): void {
+    // example1 user plugin declares weight: -100.
+    $with_explicit = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example1_user_user');
+    $this->assertSame(-100, $with_explicit->getWeight());
+
+    // example2 node page plugin declares weight: 35.
+    $other_weight = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example2_node_page');
+    $this->assertSame(35, $other_weight->getWeight());
+  }
+
+  /**
+   * Tests getTracking() default (TRUE) and explicit (FALSE) values.
+   */
+  public function testGetTracking(): void {
+    // example1 user plugin declares tracking: FALSE.
+    $no_tracking = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example1_user_user');
+    $this->assertFalse($no_tracking->getTracking());
+
+    // example1 tags plugin does not declare tracking - defaults to TRUE.
+    $defaults_to_true = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example1_taxonomy_term_tags');
+    $this->assertTrue($defaults_to_true->getTracking());
+  }
+
+  /**
+   * Tests getEntityType() / getBundle() expose plugin definition values.
+   */
+  public function testGetEntityTypeAndBundle(): void {
+    $plugin = $this->container->get('plugin.manager.generated_content')
+      ->createInstance('example2_node_article');
+
+    $this->assertSame('node', $plugin->getEntityType());
+    $this->assertSame('article', $plugin->getBundle());
+  }
+
+}

--- a/tests/src/Kernel/GeneratedContentRepositoryBatchTest.php
+++ b/tests/src/Kernel/GeneratedContentRepositoryBatchTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Kernel;
+
+use Drupal\generated_content\GeneratedContentRepository;
+
+/**
+ * Tests the batch/info/cache methods of GeneratedContentRepository.
+ *
+ * The original GeneratedContentRepositoryTest already covers the
+ * singleton and tracked/non-tracked entity flows. This file targets
+ * the remaining methods: createBatch / removeBatch / regenerateBatch,
+ * findInfo, isEmpty, clearCaches, and reset behaviour.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\GeneratedContentRepository
+ */
+class GeneratedContentRepositoryBatchTest extends GeneratedContentKernelTestBase {
+
+  /**
+   * Tests createBatch() queues create operations via GeneratedContentBatch.
+   */
+  public function testCreateBatch(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $batch =& batch_get();
+    $batch = NULL;
+
+    $info_items = [
+      ['entity_type' => 'node', 'bundle' => 'page', '#plugin_id' => 'p', '#tracking' => TRUE, '#weight' => 0, '#module' => 'm'],
+      ['entity_type' => 'user', 'bundle' => 'user', '#plugin_id' => 'p2', '#tracking' => TRUE, '#weight' => 0, '#module' => 'm'],
+    ];
+
+    $repository->createBatch($info_items);
+
+    $set = $this->lastBatchSet();
+    $this->assertCount(2, $set['operations']);
+    foreach ($set['operations'] as $op) {
+      $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::createSingle', $op[0]);
+    }
+  }
+
+  /**
+   * Tests removeBatch() queues remove operations.
+   */
+  public function testRemoveBatch(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $batch =& batch_get();
+    $batch = NULL;
+
+    $info_items = [
+      ['entity_type' => 'node', 'bundle' => 'page'],
+    ];
+
+    $repository->removeBatch($info_items);
+
+    $set = $this->lastBatchSet();
+    $this->assertCount(1, $set['operations']);
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::removeSingle', $set['operations'][0][0]);
+  }
+
+  /**
+   * Tests regenerateBatch() queues remove-then-create operations.
+   */
+  public function testRegenerateBatch(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $batch =& batch_get();
+    $batch = NULL;
+
+    $info_items = [
+      ['entity_type' => 'node', 'bundle' => 'page'],
+    ];
+
+    $repository->regenerateBatch($info_items);
+
+    $set = $this->lastBatchSet();
+    // One info item with regenerate -> one remove + one create.
+    $this->assertCount(2, $set['operations']);
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::removeSingle', $set['operations'][0][0]);
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatch::createSingle', $set['operations'][1][0]);
+  }
+
+  /**
+   * Tests createBatch() with NULL info falls back to repository getInfo().
+   */
+  public function testCreateBatchWithNullInfo(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $batch =& batch_get();
+    $batch = NULL;
+
+    // No plugins registered - getInfo() is empty, so no operations.
+    $repository->createBatch();
+
+    $set = $this->lastBatchSet();
+    $this->assertSame([], $set['operations']);
+  }
+
+  /**
+   * Tests findInfo() returns FALSE when nothing matches.
+   */
+  public function testFindInfoNoMatch(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $this->assertFalse($repository->findInfo('node', 'page'));
+    $this->assertFalse($repository->findInfo('nope'));
+  }
+
+  /**
+   * Tests isEmpty() reflects the tracking table state.
+   */
+  public function testIsEmpty(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    // Tracking table starts empty.
+    $this->assertTrue($repository->isEmpty());
+
+    // Add a tracked node and re-check.
+    $nodes = $this->prepareNodes(1, NULL, TRUE);
+    $repository->addEntities($nodes);
+
+    $this->assertFalse($repository->isEmpty());
+  }
+
+  /**
+   * Tests clearCaches() empties cache.data.
+   */
+  public function testClearCaches(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $cache = $this->container->get('cache.data');
+    $cache->set('repository_clear_test', 'value');
+    $this->assertNotFalse($cache->get('repository_clear_test'));
+
+    $repository->clearCaches();
+
+    $this->assertFalse($cache->get('repository_clear_test'));
+  }
+
+  /**
+   * Tests remove() runs through its full per-item / cache / message path.
+   *
+   * Repository::remove() is only invoked indirectly today (no callers in
+   * the module's own code paths) but it sits behind public API, so it
+   * needs coverage. The hook_entity_delete -> tracking-table cleanup is
+   * out of scope here - we just confirm remove() does not throw, drops
+   * the in-memory cache, and surfaces the user-facing message.
+   */
+  public function testRemove(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $nodes = $this->prepareNodes(1, NULL, TRUE);
+    $repository->addEntities($nodes);
+    $this->assertNotEmpty($repository->getEntities());
+
+    /** @var \Drupal\Core\Messenger\MessengerInterface $messenger */
+    $messenger = $this->container->get('messenger');
+    $messenger->deleteAll();
+
+    $info_items = [
+      [
+        'entity_type' => 'node',
+        'bundle' => $this->nodeTypes[0],
+        '#plugin_id' => 'p',
+        '#tracking' => TRUE,
+        '#weight' => 0,
+        '#module' => 'm',
+      ],
+    ];
+
+    $repository->remove($info_items);
+
+    $messages = array_map('strval', $messenger->messagesByType('status'));
+    $combined = implode("\n", $messages);
+    $this->assertStringContainsString('Removed all generated content', $combined);
+  }
+
+  /**
+   * Tests reset() returns a new singleton instance.
+   */
+  public function testReset(): void {
+    $original = GeneratedContentRepository::getInstance();
+    $renewed = $original->reset();
+
+    $this->assertInstanceOf(GeneratedContentRepository::class, $renewed);
+    $this->assertNotSame($original, $renewed);
+
+    // Subsequent getInstance() returns the renewed instance.
+    $this->assertSame($renewed, GeneratedContentRepository::getInstance());
+  }
+
+  /**
+   * Tests getInfo() with reset=TRUE re-collects from the plugin manager.
+   */
+  public function testGetInfoReset(): void {
+    $repository = GeneratedContentRepository::getInstance();
+
+    $first = $repository->getInfo();
+    $second = $repository->getInfo(TRUE);
+
+    $this->assertSame($first, $second);
+  }
+
+  /**
+   * Return the most recently queued batch set.
+   *
+   * @return array<mixed>
+   *   Batch set descriptor.
+   */
+  protected function lastBatchSet(): array {
+    $batch =& batch_get();
+    $this->assertIsArray($batch);
+    $this->assertArrayHasKey('sets', $batch);
+    $this->assertNotEmpty($batch['sets']);
+
+    return end($batch['sets']);
+  }
+
+}

--- a/tests/src/Unit/GeneratedContentCommandsTest.php
+++ b/tests/src/Unit/GeneratedContentCommandsTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Unit;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\generated_content\Commands\GeneratedContentCommands;
+
+/**
+ * Tests the GeneratedContentCommands Drush command.
+ *
+ * The createContent() entry point calls global batch_set() and
+ * drush_backend_batch_process(), which can only be exercised in a
+ * Functional environment. The internal BatchBuilder construction is
+ * the testable surface and is covered here via the protected
+ * buildBatch() method (reached through Reflection).
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Commands\GeneratedContentCommands
+ */
+class GeneratedContentCommandsTest extends GeneratedContentUnitTestBase {
+
+  /**
+   * Tests that the constructor wires the logger factory.
+   */
+  public function testConstructorWiresLoggerFactory(): void {
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $commands = new GeneratedContentCommands($logger_factory);
+
+    $this->assertSame(
+      $logger_factory,
+      $this->getProtectedProperty($commands, 'loggerChannelFactory')
+    );
+  }
+
+  /**
+   * Tests that buildBatch() produces the expected number of operations.
+   *
+   * @param int $total
+   *   Total items requested.
+   * @param int $expected_operations
+   *   Expected operation count in the BatchBuilder array.
+   *
+   * @dataProvider dataProviderBuildBatchOperationCount
+   */
+  public function testBuildBatchOperationCount(int $total, int $expected_operations): void {
+    $array = $this->callBuildBatch('node', 'page', $total);
+
+    $this->assertCount($expected_operations, $array['operations']);
+  }
+
+  /**
+   * Data provider for testBuildBatchOperationCount().
+   *
+   * Items are chunked into batches of 50. The exit condition is
+   * checked at the top of the for-loop, so total=0 produces no
+   * operations and total=50 stays at one operation.
+   *
+   * @return array<string, array<int>>
+   *   Provider data.
+   */
+  public static function dataProviderBuildBatchOperationCount(): array {
+    return [
+      'zero items queue zero batches' => [0, 0],
+      'one item fits in one batch' => [1, 1],
+      'forty-nine items fit in one batch' => [49, 1],
+      'fifty items fit in one batch' => [50, 1],
+      'fifty-one items need two batches' => [51, 2],
+      'one hundred items fit in two batches' => [100, 2],
+      'two hundred items need four batches' => [200, 4],
+    ];
+  }
+
+  /**
+   * Tests the operation callback and argument shape.
+   */
+  public function testBuildBatchOperationShape(): void {
+    $array = $this->callBuildBatch('user', 'user', 75);
+
+    $this->assertCount(2, $array['operations']);
+
+    foreach ($array['operations'] as $index => $operation) {
+      [$callback, $args] = $operation;
+      $this->assertSame('\Drupal\generated_content\GeneratedContentBatchService::processItem', $callback);
+
+      [$batch_id, $entity_type, $bundle, $total, $count] = $args;
+      $this->assertSame($index + 1, $batch_id);
+      $this->assertSame('user', $entity_type);
+      $this->assertSame('user', $bundle);
+      $this->assertSame(75, $total);
+    }
+
+    // Cumulative count is 50 then 100 in the current implementation.
+    $this->assertSame(50, $array['operations'][0][1][4]);
+    $this->assertSame(100, $array['operations'][1][1][4]);
+  }
+
+  /**
+   * Tests that buildBatch() wires finish callback and error message.
+   */
+  public function testBuildBatchCallbacksAndMessages(): void {
+    $array = $this->callBuildBatch('node', 'article', 10);
+
+    $this->assertSame('\Drupal\generated_content\GeneratedContentBatchService::processItemFinished', $array['finished']);
+    $this->assertNotEmpty((string) $array['error_message']);
+    $this->assertNotEmpty((string) $array['title']);
+    $this->assertStringContainsString('node', (string) $array['title']);
+    $this->assertStringContainsString('article', (string) $array['title']);
+    $this->assertStringContainsString('10', (string) $array['title']);
+  }
+
+  /**
+   * Build a Commands instance, call buildBatch() via Reflection.
+   *
+   * @param string $entity_type
+   *   Entity type.
+   * @param string $bundle
+   *   Bundle.
+   * @param int $total
+   *   Total.
+   *
+   * @return array<mixed>
+   *   The BatchBuilder->toArray() output.
+   */
+  protected function callBuildBatch(string $entity_type, string $bundle, int $total): array {
+    $logger_factory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $commands = new GeneratedContentCommands($logger_factory);
+
+    $translation = $this->createMock(TranslationInterface::class);
+    $translation->method('translateString')->willReturnCallback(static function ($translatable) {
+      return (string) $translatable->getUntranslatedString();
+    });
+    $commands->setStringTranslation($translation);
+
+    $reflection = new \ReflectionClass($commands);
+    $method = $reflection->getMethod('buildBatch');
+    $method->setAccessible(TRUE);
+
+    /** @var \Drupal\Core\Batch\BatchBuilder $builder */
+    $builder = $method->invoke($commands, $entity_type, $bundle, $total);
+    $this->assertInstanceOf(BatchBuilder::class, $builder);
+
+    return $builder->toArray();
+  }
+
+  /**
+   * Read a protected property via Reflection.
+   *
+   * @param object $object
+   *   Target instance.
+   * @param string $property
+   *   Property name.
+   *
+   * @return mixed
+   *   The property value.
+   */
+  protected function getProtectedProperty(object $object, string $property) {
+    $reflection = new \ReflectionClass($object);
+    $prop = $reflection->getProperty($property);
+    $prop->setAccessible(TRUE);
+
+    return $prop->getValue($object);
+  }
+
+}

--- a/tests/src/Unit/GeneratedContentCommandsTest.php
+++ b/tests/src/Unit/GeneratedContentCommandsTest.php
@@ -138,7 +138,6 @@ class GeneratedContentCommandsTest extends GeneratedContentUnitTestBase {
 
     $reflection = new \ReflectionClass($commands);
     $method = $reflection->getMethod('buildBatch');
-    $method->setAccessible(TRUE);
 
     /** @var \Drupal\Core\Batch\BatchBuilder $builder */
     $builder = $method->invoke($commands, $entity_type, $bundle, $total);
@@ -161,7 +160,6 @@ class GeneratedContentCommandsTest extends GeneratedContentUnitTestBase {
   protected function getProtectedProperty(object $object, string $property) {
     $reflection = new \ReflectionClass($object);
     $prop = $reflection->getProperty($property);
-    $prop->setAccessible(TRUE);
 
     return $prop->getValue($object);
   }

--- a/tests/src/Unit/GeneratedContentCommandsTest.php
+++ b/tests/src/Unit/GeneratedContentCommandsTest.php
@@ -111,6 +111,35 @@ class GeneratedContentCommandsTest extends GeneratedContentUnitTestBase {
     $this->assertStringContainsString('node', (string) $array['title']);
     $this->assertStringContainsString('article', (string) $array['title']);
     $this->assertStringContainsString('10', (string) $array['title']);
+    // Total of 10 chunks into a single 50-item batch.
+    $this->assertStringContainsString('1 batches', (string) $array['title']);
+  }
+
+  /**
+   * Tests that the @batches placeholder matches the actual operation count.
+   *
+   * @param int $total
+   *   Total items.
+   * @param int $expected_batches
+   *   Expected batch count reported in the title.
+   *
+   * @dataProvider dataProviderBuildBatchTitleBatchCount
+   */
+  public function testBuildBatchTitleBatchCount(int $total, int $expected_batches): void {
+    $array = $this->callBuildBatch('node', 'page', $total);
+
+    $this->assertCount($expected_batches, $array['operations']);
+    $this->assertStringContainsString(sprintf('%d batches', $expected_batches), (string) $array['title']);
+  }
+
+  /**
+   * Data provider for testBuildBatchTitleBatchCount().
+   *
+   * @return array<string, array<int>>
+   *   Provider data.
+   */
+  public static function dataProviderBuildBatchTitleBatchCount(): array {
+    return self::dataProviderBuildBatchOperationCount();
   }
 
   /**

--- a/tests/src/Unit/GeneratedContentCommandsTest.php
+++ b/tests/src/Unit/GeneratedContentCommandsTest.php
@@ -87,7 +87,7 @@ class GeneratedContentCommandsTest extends GeneratedContentUnitTestBase {
       [$callback, $args] = $operation;
       $this->assertSame('\Drupal\generated_content\GeneratedContentBatchService::processItem', $callback);
 
-      [$batch_id, $entity_type, $bundle, $total, $count] = $args;
+      [$batch_id, $entity_type, $bundle, $total] = $args;
       $this->assertSame($index + 1, $batch_id);
       $this->assertSame('user', $entity_type);
       $this->assertSame('user', $bundle);

--- a/tests/src/Unit/GeneratedContentHelperReplaceTokensTest.php
+++ b/tests/src/Unit/GeneratedContentHelperReplaceTokensTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Unit;
+
+use Drupal\generated_content\Helpers\GeneratedContentHelper;
+
+/**
+ * Tests GeneratedContentHelper::replaceTokens().
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Helpers\GeneratedContentHelper::replaceTokens
+ */
+class GeneratedContentHelperReplaceTokensTest extends GeneratedContentUnitTestBase {
+
+  /**
+   * Tests scalar replacement with default delimiters.
+   */
+  public function testReplaceTokensScalarValues(): void {
+    $result = GeneratedContentHelper::replaceTokens(
+      'Hello {name}, you have {count} new messages.',
+      ['name' => 'Alex', 'count' => 3]
+    );
+
+    $this->assertSame('Hello Alex, you have 3 new messages.', $result);
+  }
+
+  /**
+   * Tests that non-scalar values are skipped.
+   */
+  public function testReplaceTokensSkipsNonScalars(): void {
+    $result = GeneratedContentHelper::replaceTokens(
+      'Keep {arr} and {obj} unchanged, replace {str}.',
+      [
+        'arr' => ['x', 'y'],
+        'obj' => new \stdClass(),
+        'str' => 'OK',
+      ]
+    );
+
+    $this->assertStringContainsString('{arr}', $result);
+    $this->assertStringContainsString('{obj}', $result);
+    $this->assertStringContainsString('OK', $result);
+  }
+
+  /**
+   * Tests that a callback transforms the value before insertion.
+   */
+  public function testReplaceTokensWithCallback(): void {
+    $result = GeneratedContentHelper::replaceTokens(
+      'Loud: {value}',
+      ['value' => 'whisper'],
+      static fn($v) => is_string($v) ? strtoupper($v) : $v
+    );
+
+    $this->assertSame('Loud: WHISPER', $result);
+  }
+
+  /**
+   * Tests custom begin/end token delimiters.
+   */
+  public function testReplaceTokensCustomDelimiters(): void {
+    $result = GeneratedContentHelper::replaceTokens(
+      'Hello [[name]]!',
+      ['name' => 'World'],
+      NULL,
+      '[[',
+      ']]'
+    );
+
+    $this->assertSame('Hello World!', $result);
+  }
+
+  /**
+   * Tests that strings with no replacements are returned unchanged.
+   */
+  public function testReplaceTokensNoReplacements(): void {
+    $result = GeneratedContentHelper::replaceTokens('Static text', []);
+
+    $this->assertSame('Static text', $result);
+  }
+
+}

--- a/tests/src/Unit/GeneratedContentIgnoreFilterTest.php
+++ b/tests/src/Unit/GeneratedContentIgnoreFilterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\generated_content\Unit;
+
+use Drupal\generated_content\Plugin\ConfigFilter\GeneratedContentIgnoreFilter;
+
+/**
+ * Tests the GeneratedContentIgnoreFilter config filter.
+ *
+ * @group generated_content
+ *
+ * @covers \Drupal\generated_content\Plugin\ConfigFilter\GeneratedContentIgnoreFilter
+ */
+class GeneratedContentIgnoreFilterTest extends GeneratedContentUnitTestBase {
+
+  /**
+   * Tests filterWrite() with various config name / data combinations.
+   *
+   * @param string $name
+   *   The config name being written.
+   * @param array<mixed> $data
+   *   The config data being written.
+   * @param array<mixed> $expected
+   *   The expected data after filtering.
+   *
+   * @dataProvider dataProviderFilterWrite
+   */
+  public function testFilterWrite(string $name, array $data, array $expected): void {
+    $filter = new GeneratedContentIgnoreFilter([], 'generated_content_config_ignore', []);
+
+    $this->assertSame($expected, $filter->filterWrite($name, $data));
+  }
+
+  /**
+   * Data provider for testFilterWrite().
+   *
+   * @return array<string, array<mixed>>
+   *   Provider data.
+   */
+  public static function dataProviderFilterWrite(): array {
+    return [
+      'core.extension removes generated_content from modules' => [
+        'core.extension',
+        ['module' => ['generated_content' => 0, 'node' => 0, 'user' => 0]],
+        ['module' => ['node' => 0, 'user' => 0]],
+      ],
+      'core.extension without generated_content leaves modules unchanged' => [
+        'core.extension',
+        ['module' => ['node' => 0, 'user' => 0]],
+        ['module' => ['node' => 0, 'user' => 0]],
+      ],
+      'core.extension preserves sibling keys' => [
+        'core.extension',
+        ['module' => ['generated_content' => 0, 'system' => 0], 'theme' => ['stark' => 0]],
+        ['module' => ['system' => 0], 'theme' => ['stark' => 0]],
+      ],
+      'other config name is passed through unchanged' => [
+        'system.site',
+        ['name' => 'Site', 'mail' => 'a@example.com'],
+        ['name' => 'Site', 'mail' => 'a@example.com'],
+      ],
+      'similarly named config is not filtered' => [
+        'core.extension.backup',
+        ['module' => ['generated_content' => 0]],
+        ['module' => ['generated_content' => 0]],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Summary

This PR lifts PHPUnit coverage across the module from ~69% to ~93%, extracts a `buildBatch()` method from `GeneratedContentCommands::createContent()` to make batch construction independently testable, and fixes an off-by-one bug in the batch title's `@batches` placeholder surfaced by the new tests.

## Changes

### Production

- **`src/Commands/GeneratedContentCommands.php`**: extracted a protected `buildBatch(string $entity_type, string $bundle, int $total): BatchBuilder` method from `createContent()`. Behavior is otherwise identical - the extraction exists purely so the `BatchBuilder` setup can be unit-tested without invoking the two global Drupal functions (`batch_set()` and `drush_backend_batch_process()`).
- **`src/Commands/GeneratedContentCommands.php`**: fixed an off-by-one in the title placeholder. `'@batches' => $batch_id` reported `N + 1` batches whenever `N` operations were queued (initial `$batch_id = 1`, post-increment after each `addOperation()`). Changed to `'@batches' => $batch_id - 1`. The new `testBuildBatchTitleBatchCount` data provider pins this.
- **`src/Helpers/GeneratedContentHelper.php`**: tightened the `replaceTokens()` parameter docblock to `array<string, mixed>` (was `array<string, string>` despite the body already guarding with `is_scalar()`).

### Test additions (13 new files, ~1,900 LOC)

Unit:

- `GeneratedContentIgnoreFilterTest` - config filter strips `generated_content` only for `core.extension`.
- `GeneratedContentCommandsTest` - constructor wiring, `buildBatch()` operation counts (data-provider-driven), operation argument shape, title/finish callbacks, batch-count title assertion (catches the off-by-one fix above).
- `GeneratedContentHelperReplaceTokensTest` - `replaceTokens()` scalar/non-scalar/callback/custom-delimiter paths.

Kernel:

- `GeneratedContentBatchServiceTest` - `create()` DI, `processItem()` message format, `processItemFinished()` cache-clear path.
- `GeneratedContentBatchTest` - `set('create'|'remove'|'regenerate')` queuing, `createSingle()` / `removeSingle()` context mutation, `finished()` cache clear + message.
- `GeneratedContentFormTest` - `getFormId()`, `buildForm()` empty/populated, `submitForm()` button dispatch (data-provider-driven), `entityInfoToLink()` per entity type (via Reflection).
- `GeneratedContentExample1PluginsTest` - the example1 `TaxonomyTermTags` placeholder plugin.
- `GeneratedContentHelperRandomTest` (expanded) - `randomTimestamp`, `randomDate`, `randomDateRange`, `randomDisperse`, and exception paths for each.
- `GeneratedContentHelperTermTreeTest` - `saveTermTree()` flat + nested, `getTermsAtDepth()` with negative-depth clamp and `load_entities=TRUE`.
- `GeneratedContentHelperVariationTest` - `variationRandomValue()`, `variationFormatInfo()` (data-provider-driven), `variationFetchAll()` with fixture directory + exception path, `variationCreateNode()` with/without post-process callback.
- `GeneratedContentRepositoryBatchTest` - `createBatch` / `removeBatch` / `regenerateBatch` queuing, `findInfo` no-match, `isEmpty`, `clearCaches`, `remove()`, `reset()`, `getInfo(reset=TRUE)`.
- `GeneratedContentPluginBaseTest` - `resolveHelper()` default and custom-helper branches via example1 and example2 plugins; `getWeight()` / `getTracking()` defaults vs explicit.

Fixture:

- `tests/fixtures/variations/01.gc_test_helper.inc` - PHP user functions exercised by `variationFetchAll()` happy-path test.

### Coverage summary (unit + kernel)

| Class | Before | After |
|---|---|---|
| `GeneratedContentIgnoreFilter` | 0% | 100% |
| `GeneratedContentBatchService` | 0% | 100% |
| `GeneratedContentForm` | 0% | 100% |
| `TaxonomyTermTags` (example1) | 0% | 100% |
| `GeneratedContentBatch` | 0% | 87% |
| `GeneratedContentCommands` | 0% | 82% |
| `GeneratedContentPluginBase` | 78% | 100% |
| `GeneratedContentVariationTrait` | 58% | 100% |
| `GeneratedContentRandomTrait` | 52% | 99% |
| `GeneratedContentRepository` | 70% | 75% |
| `GeneratedContentHelper` | 80% | 82% |

Codecov reports project coverage at **92.81% (+23.80pp vs base)**.

## Before / After

`createContent()` before extraction - batch setup inline, untestable in isolation:

```
createContent()
  └── new BatchBuilder()
        ├── for ($count = 0; $count < $total; ) addOperation(...)
        ├── setTitle(...)
        ├── setFinishCallback(...)
        └── setErrorMessage(...)
  └── batch_set($batch->toArray())
  └── drush_backend_batch_process()
```

After extraction - `createContent()` delegates the testable surface to `buildBatch()`:

```
createContent()
  └── $this->buildBatch(...)            ← unit-tested (op count, arg shape, title, callbacks)
  └── batch_set($batch->toArray())      ← global, only reachable in Functional
  └── drush_backend_batch_process()     ← global, only reachable in Functional
```

## Notes

- `codecov/patch` is failing because the patch coverage of `createContent()` is 20% - the four remaining lines are `logger->info()` x2 and the two global functions above, which PHPUnit cannot cover from a Unit test. Project coverage (the more meaningful number) increased by ~24 percentage points.
- The functional suite has 9 pre-existing failures on `2.x` (`drupalLogin` post-condition on `UiHelperTrait::186`) unrelated to this branch; CI runs in a clean environment and is unaffected.
